### PR TITLE
CMake support for installing libraries as components of the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,3 +33,32 @@ add_subdirectory(src/r1_cartesian_control)
 
 # Add standard uninstall target
 include(AddUninstallTarget)
+
+# Configure package config file to support components
+include(CMakePackageConfigHelpers)
+
+# Create the config file
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    @ONLY
+)
+
+# Write version file
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+# Install export targets
+install(EXPORT ${PROJECT_NAME}Targets
+    FILE ${PROJECT_NAME}Targets.cmake
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION lib/cmake/${PROJECT_NAME}
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    DESTINATION lib/cmake/${PROJECT_NAME}
+)

--- a/cmake/ergocub-cartesian-controlConfig.cmake.in
+++ b/cmake/ergocub-cartesian-controlConfig.cmake.in
@@ -1,0 +1,29 @@
+@PACKAGE_INIT@
+
+# Declare the components
+set(_supported_components
+    utils
+    cub-joint-control
+    trajectory-generator
+    gb-ergocub-cartesian-service
+)
+
+# Handle components
+foreach(_comp ${@PROJECT_NAME@_FIND_COMPONENTS})
+    if(NOT _comp IN_LIST _supported_components)
+        set(@PROJECT_NAME@_FOUND FALSE)
+        set(@PROJECT_NAME@_NOTFOUND_MESSAGE "Unsupported component: ${_comp}")
+        return()
+    endif()
+    
+    # Include the component's config file if it exists
+    include(${CMAKE_CURRENT_LIST_DIR}/${_comp}Config.cmake OPTIONAL)
+    
+    # Include component targets
+    include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake OPTIONAL)
+endforeach()
+
+# Check dependencies
+include(CMakeFindDependencyMacro)
+find_dependency(YARP COMPONENTS dev os)
+find_dependency(Eigen3)

--- a/src/cub_joint_control/CMakeLists.txt
+++ b/src/cub_joint_control/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(LIBRARY_TARGET_NAME cub-joint-control)
 
 # YARP
-find_package(YARP REQUIRED COMPONENTS idl_tools sig)
+find_package(YARP REQUIRED COMPONENTS dev os)
 
 # Eigen3
 find_package(Eigen3 REQUIRED)
@@ -19,12 +19,33 @@ set(${LIBRARY_TARGET_NAME}_SRC
 add_library(${LIBRARY_TARGET_NAME} STATIC ${${LIBRARY_TARGET_NAME}_SRC} ${${LIBRARY_TARGET_NAME}_HDR})
 
 # Library properties
-set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES VERSION       ${${PROJECT_NAME}_VERSION}
-                                                        PUBLIC_HEADER "${${LIBRARY_TARGET_NAME}_HDR}")
+set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES 
+    VERSION       ${${PROJECT_NAME}_VERSION}
+    PUBLIC_HEADER "${${LIBRARY_TARGET_NAME}_HDR}"
+    EXPORT_NAME   cub-joint-control  # Set consistent export name
+)
 
 # Include directories
 target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                          "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
 
 # Linker configuration
-target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC YARP::YARP_os YARP::YARP_sig Eigen3::Eigen utils)
+target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC YARP::YARP_os YARP::YARP_sig Eigen3::Eigen 
+                                             PRIVATE utils)
+
+             
+# Install the headers explicitly to ensure they're available
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
+                                             
+
+# Export the target to a different export set than the one used for installation
+install(TARGETS ${LIBRARY_TARGET_NAME}
+    EXPORT  ${PROJECT_NAME}Targets  # Use the parent project's export name
+    LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                          COMPONENT shlib
+    ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                          COMPONENT lib
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}" COMPONENT dev
+)

--- a/src/ergocub_cartesian_service/CMakeLists.txt
+++ b/src/ergocub_cartesian_service/CMakeLists.txt
@@ -36,8 +36,10 @@ set(${LIBRARY_TARGET_NAME}_SRC
 add_library(${LIBRARY_TARGET_NAME} ${${LIBRARY_TARGET_NAME}_SRC} ${${LIBRARY_TARGET_NAME}_HDR})
 
 # Library properties
-set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES VERSION       ${${PROJECT_NAME}_VERSION}
-                                                        PUBLIC_HEADER "${${LIBRARY_TARGET_NAME}_HDR}")
+set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES 
+    PUBLIC_HEADER "${headers}"
+    EXPORT_NAME ${LIBRARY_TARGET_NAME}  # Set consistent export name
+)
 
 # Include directories
 target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -46,22 +48,18 @@ target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CM
 # Linker configuration
 target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC YARP::YARP_os YARP::YARP_sig)
 
-# Specify installation targets, type and destination folders.
-install(TARGETS ${LIBRARY_TARGET_NAME}
-        EXPORT  ${LIBRARY_TARGET_NAME}
-        LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                                   COMPONENT shlib
-        ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                                   COMPONENT lib
-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}"        COMPONENT dev
+# Install the headers explicitly to ensure they're available
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
 )
-set_property(GLOBAL APPEND PROPERTY ${PROJECT_NAME}_TARGETS ${LIBRARY_TARGET_NAME})
 
-# Install the library
-set(DEPENDENCIES "YARP COMPONENTS os sig")
-install_basic_package_files(${LIBRARY_TARGET_NAME}
-                            VERSION ${${PROJECT_NAME}_VERSION}
-                            COMPATIBILITY ExactVersion
-                            EXPORT ${LIBRARY_TARGET_NAME}
-                            NO_SET_AND_CHECK_MACRO
-                            VARS_PREFIX ${LIBRARY_TARGET_NAME}
-                            NO_CHECK_REQUIRED_COMPONENTS_MACRO
-                            DEPENDENCIES ${DEPENDENCIES})
+
+# Install the targets
+install(TARGETS ${LIBRARY_TARGET_NAME}
+    EXPORT  ${PROJECT_NAME}Targets  # Use the parent project's export name
+    LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}" 
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}"
+)

--- a/src/ergocub_cartesian_service/include/gb-ergocub-cartesian-service/ergoCubCartesianService.h
+++ b/src/ergocub_cartesian_service/include/gb-ergocub-cartesian-service/ergoCubCartesianService.h
@@ -22,9 +22,15 @@ public:
     // Constructor
     ergoCubCartesianService();
 
-    virtual bool go_to_pose(const yarp::sig::Matrix& pose, const double traj_duration);
+    virtual bool go_to_pose(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w, const double traj_duration);
 
     virtual bool go_to_position(const double x, const double y, const double z, const double traj_duration);
+
+    virtual bool rotate_rad(const double angle, const double x, const double y, const double z, const double traj_duration);
+
+    virtual bool rotate_deg(const double angle, const double x, const double y, const double z, const double traj_duration);
+
+    virtual yarp::sig::Matrix get_pose();
 
     virtual bool go_home();
 

--- a/src/ergocub_cartesian_service/src/ergoCubCartesianService.cpp
+++ b/src/ergocub_cartesian_service/src/ergoCubCartesianService.cpp
@@ -20,7 +20,7 @@ class ergoCubCartesianService_go_to_pose_helper :
 {
 public:
     ergoCubCartesianService_go_to_pose_helper() = default;
-    ergoCubCartesianService_go_to_pose_helper(const yarp::sig::Matrix& pose, const double traj_duration);
+    ergoCubCartesianService_go_to_pose_helper(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w, const double traj_duration);
     bool write(yarp::os::ConnectionWriter& connection) const override;
     bool read(yarp::os::ConnectionReader& connection) override;
 
@@ -29,7 +29,7 @@ public:
     {
     public:
         Command() = default;
-        Command(const yarp::sig::Matrix& pose, const double traj_duration);
+        Command(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w, const double traj_duration);
 
         ~Command() override = default;
 
@@ -44,7 +44,13 @@ public:
         bool readTag(yarp::os::idl::WireReader& reader);
         bool readArgs(yarp::os::idl::WireReader& reader);
 
-        yarp::sig::Matrix pose{};
+        double x{0.0};
+        double y{0.0};
+        double z{0.0};
+        double q_x{0.0};
+        double q_y{0.0};
+        double q_z{0.0};
+        double q_w{0.0};
         double traj_duration{0.0};
     };
 
@@ -64,7 +70,7 @@ public:
         bool return_helper{false};
     };
 
-    using funcptr_t = bool (*)(const yarp::sig::Matrix&, const double);
+    using funcptr_t = bool (*)(const double, const double, const double, const double, const double, const double, const double, const double);
     void call(ergoCubCartesianService* ptr);
 
     Command cmd;
@@ -72,9 +78,9 @@ public:
 
     static constexpr const char* s_tag{"go_to_pose"};
     static constexpr size_t s_tag_len{3};
-    static constexpr size_t s_cmd_len{5};
+    static constexpr size_t s_cmd_len{11};
     static constexpr size_t s_reply_len{1};
-    static constexpr const char* s_prototype{"bool ergoCubCartesianService::go_to_pose(const yarp::sig::Matrix& pose, const double traj_duration)"};
+    static constexpr const char* s_prototype{"bool ergoCubCartesianService::go_to_pose(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w, const double traj_duration)"};
     static constexpr const char* s_help{""};
 };
 
@@ -141,6 +147,198 @@ public:
     static constexpr size_t s_cmd_len{7};
     static constexpr size_t s_reply_len{1};
     static constexpr const char* s_prototype{"bool ergoCubCartesianService::go_to_position(const double x, const double y, const double z, const double traj_duration)"};
+    static constexpr const char* s_help{""};
+};
+
+// rotate_rad helper class declaration
+class ergoCubCartesianService_rotate_rad_helper :
+        public yarp::os::Portable
+{
+public:
+    ergoCubCartesianService_rotate_rad_helper() = default;
+    ergoCubCartesianService_rotate_rad_helper(const double angle, const double x, const double y, const double z, const double traj_duration);
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    class Command :
+            public yarp::os::idl::WirePortable
+    {
+    public:
+        Command() = default;
+        Command(const double angle, const double x, const double y, const double z, const double traj_duration);
+
+        ~Command() override = default;
+
+        bool write(yarp::os::ConnectionWriter& connection) const override;
+        bool read(yarp::os::ConnectionReader& connection) override;
+
+        bool write(const yarp::os::idl::WireWriter& writer) const override;
+        bool writeTag(const yarp::os::idl::WireWriter& writer) const;
+        bool writeArgs(const yarp::os::idl::WireWriter& writer) const;
+
+        bool read(yarp::os::idl::WireReader& reader) override;
+        bool readTag(yarp::os::idl::WireReader& reader);
+        bool readArgs(yarp::os::idl::WireReader& reader);
+
+        double angle{0.0};
+        double x{0.0};
+        double y{0.0};
+        double z{0.0};
+        double traj_duration{0.0};
+    };
+
+    class Reply :
+            public yarp::os::idl::WirePortable
+    {
+    public:
+        Reply() = default;
+        ~Reply() override = default;
+
+        bool write(yarp::os::ConnectionWriter& connection) const override;
+        bool read(yarp::os::ConnectionReader& connection) override;
+
+        bool write(const yarp::os::idl::WireWriter& writer) const override;
+        bool read(yarp::os::idl::WireReader& reader) override;
+
+        bool return_helper{false};
+    };
+
+    using funcptr_t = bool (*)(const double, const double, const double, const double, const double);
+    void call(ergoCubCartesianService* ptr);
+
+    Command cmd;
+    Reply reply;
+
+    static constexpr const char* s_tag{"rotate_rad"};
+    static constexpr size_t s_tag_len{2};
+    static constexpr size_t s_cmd_len{7};
+    static constexpr size_t s_reply_len{1};
+    static constexpr const char* s_prototype{"bool ergoCubCartesianService::rotate_rad(const double angle, const double x, const double y, const double z, const double traj_duration)"};
+    static constexpr const char* s_help{""};
+};
+
+// rotate_deg helper class declaration
+class ergoCubCartesianService_rotate_deg_helper :
+        public yarp::os::Portable
+{
+public:
+    ergoCubCartesianService_rotate_deg_helper() = default;
+    ergoCubCartesianService_rotate_deg_helper(const double angle, const double x, const double y, const double z, const double traj_duration);
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    class Command :
+            public yarp::os::idl::WirePortable
+    {
+    public:
+        Command() = default;
+        Command(const double angle, const double x, const double y, const double z, const double traj_duration);
+
+        ~Command() override = default;
+
+        bool write(yarp::os::ConnectionWriter& connection) const override;
+        bool read(yarp::os::ConnectionReader& connection) override;
+
+        bool write(const yarp::os::idl::WireWriter& writer) const override;
+        bool writeTag(const yarp::os::idl::WireWriter& writer) const;
+        bool writeArgs(const yarp::os::idl::WireWriter& writer) const;
+
+        bool read(yarp::os::idl::WireReader& reader) override;
+        bool readTag(yarp::os::idl::WireReader& reader);
+        bool readArgs(yarp::os::idl::WireReader& reader);
+
+        double angle{0.0};
+        double x{0.0};
+        double y{0.0};
+        double z{0.0};
+        double traj_duration{0.0};
+    };
+
+    class Reply :
+            public yarp::os::idl::WirePortable
+    {
+    public:
+        Reply() = default;
+        ~Reply() override = default;
+
+        bool write(yarp::os::ConnectionWriter& connection) const override;
+        bool read(yarp::os::ConnectionReader& connection) override;
+
+        bool write(const yarp::os::idl::WireWriter& writer) const override;
+        bool read(yarp::os::idl::WireReader& reader) override;
+
+        bool return_helper{false};
+    };
+
+    using funcptr_t = bool (*)(const double, const double, const double, const double, const double);
+    void call(ergoCubCartesianService* ptr);
+
+    Command cmd;
+    Reply reply;
+
+    static constexpr const char* s_tag{"rotate_deg"};
+    static constexpr size_t s_tag_len{2};
+    static constexpr size_t s_cmd_len{7};
+    static constexpr size_t s_reply_len{1};
+    static constexpr const char* s_prototype{"bool ergoCubCartesianService::rotate_deg(const double angle, const double x, const double y, const double z, const double traj_duration)"};
+    static constexpr const char* s_help{""};
+};
+
+// get_pose helper class declaration
+class ergoCubCartesianService_get_pose_helper :
+        public yarp::os::Portable
+{
+public:
+    ergoCubCartesianService_get_pose_helper() = default;
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    class Command :
+            public yarp::os::idl::WirePortable
+    {
+    public:
+        Command() = default;
+        ~Command() override = default;
+
+        bool write(yarp::os::ConnectionWriter& connection) const override;
+        bool read(yarp::os::ConnectionReader& connection) override;
+
+        bool write(const yarp::os::idl::WireWriter& writer) const override;
+        bool writeTag(const yarp::os::idl::WireWriter& writer) const;
+        bool writeArgs(const yarp::os::idl::WireWriter& writer) const;
+
+        bool read(yarp::os::idl::WireReader& reader) override;
+        bool readTag(yarp::os::idl::WireReader& reader);
+        bool readArgs(yarp::os::idl::WireReader& reader);
+    };
+
+    class Reply :
+            public yarp::os::idl::WirePortable
+    {
+    public:
+        Reply() = default;
+        ~Reply() override = default;
+
+        bool write(yarp::os::ConnectionWriter& connection) const override;
+        bool read(yarp::os::ConnectionReader& connection) override;
+
+        bool write(const yarp::os::idl::WireWriter& writer) const override;
+        bool read(yarp::os::idl::WireReader& reader) override;
+
+        yarp::sig::Matrix return_helper{};
+    };
+
+    using funcptr_t = yarp::sig::Matrix (*)();
+    void call(ergoCubCartesianService* ptr);
+
+    Command cmd;
+    Reply reply;
+
+    static constexpr const char* s_tag{"get_pose"};
+    static constexpr size_t s_tag_len{2};
+    static constexpr size_t s_cmd_len{2};
+    static constexpr size_t s_reply_len{1};
+    static constexpr const char* s_prototype{"yarp::sig::Matrix ergoCubCartesianService::get_pose()"};
     static constexpr const char* s_help{""};
 };
 
@@ -440,8 +638,8 @@ public:
 };
 
 // go_to_pose helper class implementation
-ergoCubCartesianService_go_to_pose_helper::ergoCubCartesianService_go_to_pose_helper(const yarp::sig::Matrix& pose, const double traj_duration) :
-        cmd{pose, traj_duration}
+ergoCubCartesianService_go_to_pose_helper::ergoCubCartesianService_go_to_pose_helper(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w, const double traj_duration) :
+        cmd{x, y, z, q_x, q_y, q_z, q_w, traj_duration}
 {
 }
 
@@ -455,8 +653,14 @@ bool ergoCubCartesianService_go_to_pose_helper::read(yarp::os::ConnectionReader&
     return reply.read(connection);
 }
 
-ergoCubCartesianService_go_to_pose_helper::Command::Command(const yarp::sig::Matrix& pose, const double traj_duration) :
-        pose{pose},
+ergoCubCartesianService_go_to_pose_helper::Command::Command(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w, const double traj_duration) :
+        x{x},
+        y{y},
+        z{z},
+        q_x{q_x},
+        q_y{q_y},
+        q_z{q_z},
+        q_w{q_w},
         traj_duration{traj_duration}
 {
 }
@@ -501,7 +705,25 @@ bool ergoCubCartesianService_go_to_pose_helper::Command::writeTag(const yarp::os
 
 bool ergoCubCartesianService_go_to_pose_helper::Command::writeArgs(const yarp::os::idl::WireWriter& writer) const
 {
-    if (!writer.writeNested(pose)) {
+    if (!writer.writeFloat64(x)) {
+        return false;
+    }
+    if (!writer.writeFloat64(y)) {
+        return false;
+    }
+    if (!writer.writeFloat64(z)) {
+        return false;
+    }
+    if (!writer.writeFloat64(q_x)) {
+        return false;
+    }
+    if (!writer.writeFloat64(q_y)) {
+        return false;
+    }
+    if (!writer.writeFloat64(q_z)) {
+        return false;
+    }
+    if (!writer.writeFloat64(q_w)) {
         return false;
     }
     if (!writer.writeFloat64(traj_duration)) {
@@ -540,7 +762,55 @@ bool ergoCubCartesianService_go_to_pose_helper::Command::readArgs(yarp::os::idl:
         reader.fail();
         return false;
     }
-    if (!reader.readNested(pose)) {
+    if (!reader.readFloat64(x)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(y)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(z)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(q_x)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(q_y)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(q_z)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(q_w)) {
         reader.fail();
         return false;
     }
@@ -602,7 +872,7 @@ bool ergoCubCartesianService_go_to_pose_helper::Reply::read(yarp::os::idl::WireR
 
 void ergoCubCartesianService_go_to_pose_helper::call(ergoCubCartesianService* ptr)
 {
-    reply.return_helper = ptr->go_to_pose(cmd.pose, cmd.traj_duration);
+    reply.return_helper = ptr->go_to_pose(cmd.x, cmd.y, cmd.z, cmd.q_x, cmd.q_y, cmd.q_z, cmd.q_w, cmd.traj_duration);
 }
 
 // go_to_position helper class implementation
@@ -793,6 +1063,537 @@ bool ergoCubCartesianService_go_to_position_helper::Reply::read(yarp::os::idl::W
 void ergoCubCartesianService_go_to_position_helper::call(ergoCubCartesianService* ptr)
 {
     reply.return_helper = ptr->go_to_position(cmd.x, cmd.y, cmd.z, cmd.traj_duration);
+}
+
+// rotate_rad helper class implementation
+ergoCubCartesianService_rotate_rad_helper::ergoCubCartesianService_rotate_rad_helper(const double angle, const double x, const double y, const double z, const double traj_duration) :
+        cmd{angle, x, y, z, traj_duration}
+{
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    return cmd.write(connection);
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::read(yarp::os::ConnectionReader& connection)
+{
+    return reply.read(connection);
+}
+
+ergoCubCartesianService_rotate_rad_helper::Command::Command(const double angle, const double x, const double y, const double z, const double traj_duration) :
+        angle{angle},
+        x{x},
+        y{y},
+        z{z},
+        traj_duration{traj_duration}
+{
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Command::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(s_cmd_len)) {
+        return false;
+    }
+    return write(writer);
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Command::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListHeader()) {
+        reader.fail();
+        return false;
+    }
+    return read(reader);
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Command::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writeTag(writer)) {
+        return false;
+    }
+    if (!writeArgs(writer)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Command::writeTag(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeTag(s_tag, 1, s_tag_len)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Command::writeArgs(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeFloat64(angle)) {
+        return false;
+    }
+    if (!writer.writeFloat64(x)) {
+        return false;
+    }
+    if (!writer.writeFloat64(y)) {
+        return false;
+    }
+    if (!writer.writeFloat64(z)) {
+        return false;
+    }
+    if (!writer.writeFloat64(traj_duration)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Command::read(yarp::os::idl::WireReader& reader)
+{
+    if (!readTag(reader)) {
+        return false;
+    }
+    if (!readArgs(reader)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Command::readTag(yarp::os::idl::WireReader& reader)
+{
+    std::string tag = reader.readTag(s_tag_len);
+    if (reader.isError()) {
+        return false;
+    }
+    if (tag != s_tag) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Command::readArgs(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(angle)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(x)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(y)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(z)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(traj_duration)) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Reply::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    return write(writer);
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Reply::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    return read(reader);
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.isNull()) {
+        if (!writer.writeListHeader(s_reply_len)) {
+            return false;
+        }
+        if (!writer.writeBool(return_helper)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_rad_helper::Reply::read(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readBool(return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+void ergoCubCartesianService_rotate_rad_helper::call(ergoCubCartesianService* ptr)
+{
+    reply.return_helper = ptr->rotate_rad(cmd.angle, cmd.x, cmd.y, cmd.z, cmd.traj_duration);
+}
+
+// rotate_deg helper class implementation
+ergoCubCartesianService_rotate_deg_helper::ergoCubCartesianService_rotate_deg_helper(const double angle, const double x, const double y, const double z, const double traj_duration) :
+        cmd{angle, x, y, z, traj_duration}
+{
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    return cmd.write(connection);
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::read(yarp::os::ConnectionReader& connection)
+{
+    return reply.read(connection);
+}
+
+ergoCubCartesianService_rotate_deg_helper::Command::Command(const double angle, const double x, const double y, const double z, const double traj_duration) :
+        angle{angle},
+        x{x},
+        y{y},
+        z{z},
+        traj_duration{traj_duration}
+{
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Command::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(s_cmd_len)) {
+        return false;
+    }
+    return write(writer);
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Command::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListHeader()) {
+        reader.fail();
+        return false;
+    }
+    return read(reader);
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Command::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writeTag(writer)) {
+        return false;
+    }
+    if (!writeArgs(writer)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Command::writeTag(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeTag(s_tag, 1, s_tag_len)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Command::writeArgs(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeFloat64(angle)) {
+        return false;
+    }
+    if (!writer.writeFloat64(x)) {
+        return false;
+    }
+    if (!writer.writeFloat64(y)) {
+        return false;
+    }
+    if (!writer.writeFloat64(z)) {
+        return false;
+    }
+    if (!writer.writeFloat64(traj_duration)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Command::read(yarp::os::idl::WireReader& reader)
+{
+    if (!readTag(reader)) {
+        return false;
+    }
+    if (!readArgs(reader)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Command::readTag(yarp::os::idl::WireReader& reader)
+{
+    std::string tag = reader.readTag(s_tag_len);
+    if (reader.isError()) {
+        return false;
+    }
+    if (tag != s_tag) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Command::readArgs(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(angle)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(x)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(y)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(z)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(traj_duration)) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Reply::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    return write(writer);
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Reply::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    return read(reader);
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.isNull()) {
+        if (!writer.writeListHeader(s_reply_len)) {
+            return false;
+        }
+        if (!writer.writeBool(return_helper)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_rotate_deg_helper::Reply::read(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readBool(return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+void ergoCubCartesianService_rotate_deg_helper::call(ergoCubCartesianService* ptr)
+{
+    reply.return_helper = ptr->rotate_deg(cmd.angle, cmd.x, cmd.y, cmd.z, cmd.traj_duration);
+}
+
+// get_pose helper class implementation
+bool ergoCubCartesianService_get_pose_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    return cmd.write(connection);
+}
+
+bool ergoCubCartesianService_get_pose_helper::read(yarp::os::ConnectionReader& connection)
+{
+    return reply.read(connection);
+}
+
+bool ergoCubCartesianService_get_pose_helper::Command::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(s_cmd_len)) {
+        return false;
+    }
+    return write(writer);
+}
+
+bool ergoCubCartesianService_get_pose_helper::Command::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListHeader()) {
+        reader.fail();
+        return false;
+    }
+    return read(reader);
+}
+
+bool ergoCubCartesianService_get_pose_helper::Command::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writeTag(writer)) {
+        return false;
+    }
+    if (!writeArgs(writer)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_get_pose_helper::Command::writeTag(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeTag(s_tag, 1, s_tag_len)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_get_pose_helper::Command::writeArgs(const yarp::os::idl::WireWriter& writer [[maybe_unused]]) const
+{
+    return true;
+}
+
+bool ergoCubCartesianService_get_pose_helper::Command::read(yarp::os::idl::WireReader& reader)
+{
+    if (!readTag(reader)) {
+        return false;
+    }
+    if (!readArgs(reader)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_get_pose_helper::Command::readTag(yarp::os::idl::WireReader& reader)
+{
+    std::string tag = reader.readTag(s_tag_len);
+    if (reader.isError()) {
+        return false;
+    }
+    if (tag != s_tag) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_get_pose_helper::Command::readArgs(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_get_pose_helper::Reply::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    return write(writer);
+}
+
+bool ergoCubCartesianService_get_pose_helper::Reply::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    return read(reader);
+}
+
+bool ergoCubCartesianService_get_pose_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.isNull()) {
+        if (!writer.write(return_helper)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_get_pose_helper::Reply::read(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.read(return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+void ergoCubCartesianService_get_pose_helper::call(ergoCubCartesianService* ptr)
+{
+    reply.return_helper = ptr->get_pose();
 }
 
 // go_home helper class implementation
@@ -1481,12 +2282,12 @@ ergoCubCartesianService::ergoCubCartesianService()
     yarp().setOwner(*this);
 }
 
-bool ergoCubCartesianService::go_to_pose(const yarp::sig::Matrix& pose, const double traj_duration)
+bool ergoCubCartesianService::go_to_pose(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w, const double traj_duration)
 {
     if (!yarp().canWrite()) {
         yError("Missing server method '%s'?", ergoCubCartesianService_go_to_pose_helper::s_prototype);
     }
-    ergoCubCartesianService_go_to_pose_helper helper{pose, traj_duration};
+    ergoCubCartesianService_go_to_pose_helper helper{x, y, z, q_x, q_y, q_z, q_w, traj_duration};
     bool ok = yarp().write(helper, helper);
     return ok ? helper.reply.return_helper : bool{};
 }
@@ -1499,6 +2300,36 @@ bool ergoCubCartesianService::go_to_position(const double x, const double y, con
     ergoCubCartesianService_go_to_position_helper helper{x, y, z, traj_duration};
     bool ok = yarp().write(helper, helper);
     return ok ? helper.reply.return_helper : bool{};
+}
+
+bool ergoCubCartesianService::rotate_rad(const double angle, const double x, const double y, const double z, const double traj_duration)
+{
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", ergoCubCartesianService_rotate_rad_helper::s_prototype);
+    }
+    ergoCubCartesianService_rotate_rad_helper helper{angle, x, y, z, traj_duration};
+    bool ok = yarp().write(helper, helper);
+    return ok ? helper.reply.return_helper : bool{};
+}
+
+bool ergoCubCartesianService::rotate_deg(const double angle, const double x, const double y, const double z, const double traj_duration)
+{
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", ergoCubCartesianService_rotate_deg_helper::s_prototype);
+    }
+    ergoCubCartesianService_rotate_deg_helper helper{angle, x, y, z, traj_duration};
+    bool ok = yarp().write(helper, helper);
+    return ok ? helper.reply.return_helper : bool{};
+}
+
+yarp::sig::Matrix ergoCubCartesianService::get_pose()
+{
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", ergoCubCartesianService_get_pose_helper::s_prototype);
+    }
+    ergoCubCartesianService_get_pose_helper helper{};
+    bool ok = yarp().write(helper, helper);
+    return ok ? helper.reply.return_helper : yarp::sig::Matrix{};
 }
 
 bool ergoCubCartesianService::go_home()
@@ -1560,6 +2391,9 @@ std::vector<std::string> ergoCubCartesianService::help(const std::string& functi
         helpString.emplace_back("*** Available commands:");
         helpString.emplace_back(ergoCubCartesianService_go_to_pose_helper::s_tag);
         helpString.emplace_back(ergoCubCartesianService_go_to_position_helper::s_tag);
+        helpString.emplace_back(ergoCubCartesianService_rotate_rad_helper::s_tag);
+        helpString.emplace_back(ergoCubCartesianService_rotate_deg_helper::s_tag);
+        helpString.emplace_back(ergoCubCartesianService_get_pose_helper::s_tag);
         helpString.emplace_back(ergoCubCartesianService_go_home_helper::s_tag);
         helpString.emplace_back(ergoCubCartesianService_is_motion_done_helper::s_tag);
         helpString.emplace_back(ergoCubCartesianService_ask_reachability_evaluation_helper::s_tag);
@@ -1572,6 +2406,15 @@ std::vector<std::string> ergoCubCartesianService::help(const std::string& functi
         }
         if (functionName == ergoCubCartesianService_go_to_position_helper::s_tag) {
             helpString.emplace_back(ergoCubCartesianService_go_to_position_helper::s_prototype);
+        }
+        if (functionName == ergoCubCartesianService_rotate_rad_helper::s_tag) {
+            helpString.emplace_back(ergoCubCartesianService_rotate_rad_helper::s_prototype);
+        }
+        if (functionName == ergoCubCartesianService_rotate_deg_helper::s_tag) {
+            helpString.emplace_back(ergoCubCartesianService_rotate_deg_helper::s_prototype);
+        }
+        if (functionName == ergoCubCartesianService_get_pose_helper::s_tag) {
+            helpString.emplace_back(ergoCubCartesianService_get_pose_helper::s_prototype);
         }
         if (functionName == ergoCubCartesianService_go_home_helper::s_tag) {
             helpString.emplace_back(ergoCubCartesianService_go_home_helper::s_prototype);
@@ -1637,6 +2480,51 @@ bool ergoCubCartesianService::read(yarp::os::ConnectionReader& connection)
         }
         if (tag == ergoCubCartesianService_go_to_position_helper::s_tag) {
             ergoCubCartesianService_go_to_position_helper helper;
+            if (!helper.cmd.readArgs(reader)) {
+                return false;
+            }
+
+            helper.call(this);
+
+            yarp::os::idl::WireWriter writer(reader);
+            if (!helper.reply.write(writer)) {
+                return false;
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == ergoCubCartesianService_rotate_rad_helper::s_tag) {
+            ergoCubCartesianService_rotate_rad_helper helper;
+            if (!helper.cmd.readArgs(reader)) {
+                return false;
+            }
+
+            helper.call(this);
+
+            yarp::os::idl::WireWriter writer(reader);
+            if (!helper.reply.write(writer)) {
+                return false;
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == ergoCubCartesianService_rotate_deg_helper::s_tag) {
+            ergoCubCartesianService_rotate_deg_helper helper;
+            if (!helper.cmd.readArgs(reader)) {
+                return false;
+            }
+
+            helper.call(this);
+
+            yarp::os::idl::WireWriter writer(reader);
+            if (!helper.reply.write(writer)) {
+                return false;
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == ergoCubCartesianService_get_pose_helper::s_tag) {
+            ergoCubCartesianService_get_pose_helper helper;
             if (!helper.cmd.readArgs(reader)) {
                 return false;
             }

--- a/src/trajectory_generator/CMakeLists.txt
+++ b/src/trajectory_generator/CMakeLists.txt
@@ -19,8 +19,11 @@ set(${LIBRARY_TARGET_NAME}_SRC
 add_library(${LIBRARY_TARGET_NAME} STATIC ${${LIBRARY_TARGET_NAME}_SRC} ${${LIBRARY_TARGET_NAME}_HDR})
 
 # Library properties
-set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES VERSION       ${${PROJECT_NAME}_VERSION}
-                                                        PUBLIC_HEADER "${${LIBRARY_TARGET_NAME}_HDR}")
+set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES 
+    VERSION       ${${PROJECT_NAME}_VERSION}
+    PUBLIC_HEADER "${headers}"
+    EXPORT_NAME ${LIBRARY_TARGET_NAME}  # Set consistent export name
+)
 
 # Include directories
 target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -28,3 +31,18 @@ target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CM
 
 # Linker configuration
 target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC Eigen3::Eigen)
+
+# Install the headers explicitly to ensure they're available
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
+
+# Install the targets
+install(TARGETS ${LIBRARY_TARGET_NAME}
+    EXPORT  ${PROJECT_NAME}Targets  # Use the parent project's export name
+    LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}" 
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}"
+)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -19,8 +19,12 @@ set(${LIBRARY_TARGET_NAME}_SRC
 add_library(${LIBRARY_TARGET_NAME} STATIC ${${LIBRARY_TARGET_NAME}_SRC} ${${LIBRARY_TARGET_NAME}_HDR})
 
 # Library properties
-set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES VERSION       ${${PROJECT_NAME}_VERSION}
-                                                        PUBLIC_HEADER "${${LIBRARY_TARGET_NAME}_HDR}")
+set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES 
+    VERSION       ${${PROJECT_NAME}_VERSION}
+    PUBLIC_HEADER "${headers}"
+    EXPORT_NAME ${LIBRARY_TARGET_NAME}  # Set consistent export name
+)
+
 
 # Include directories
 target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -28,3 +32,19 @@ target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CM
 
 # Linker configuration
 target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC YARP::YARP_os YARP::YARP_sig  Eigen3::Eigen)
+
+# Install the headers explicitly to ensure they're available
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
+
+
+# Install the targets
+install(TARGETS ${LIBRARY_TARGET_NAME}
+    EXPORT  ${PROJECT_NAME}Targets  # Use the parent project's export name
+    LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}" 
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}"
+)


### PR DESCRIPTION
This pr introduces changes to CMakeLists so that is now easier to use the project using cmake in other project.

To use it in another project the user can now just write

#### CMakeLists.txt
```
find_package(ergocub-cartesian-control COMPONENTS 
             cub-joint-control 
             trajectory-generator
             gb-ergocub-cartesian-service
             utils
)

...

target_link_libraries(
             ...
             ergocub-cartesian-control::cub-joint-control
             ergocub-cartesian-control::trajectory-generator
             ...
)
```