### PR TITLE
Adding is_pose_reachable service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+**/.cache

--- a/src/ergocub_cartesian_control/include/module.h
+++ b/src/ergocub_cartesian_control/include/module.h
@@ -57,6 +57,8 @@ public:
 
     bool ask_reachability_evaluation(const yarp::sig::Matrix &pose);
 
+    bool is_pose_reachable(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w);
+
     yarp::sig::Matrix retrieve_reachable_pose();
 
     bool stop();

--- a/src/ergocub_cartesian_control/src/module_service.cpp
+++ b/src/ergocub_cartesian_control/src/module_service.cpp
@@ -111,6 +111,20 @@ bool Module::ask_reachability_evaluation(const yarp::sig::Matrix &pose)
     return true;
 }
 
+bool Module::is_pose_reachable(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w)
+{
+    if (getState() != State::Stop)
+        return false;
+
+    Eigen::Affine3d target_pose;
+    target_pose = Eigen::Translation3d(x, y, z);
+    target_pose.rotate(Eigen::Quaterniond(q_w, q_x, q_y, q_z));
+
+    serviceTrajInit(true, target_pose, getDuration());
+
+    return true;
+}
+
 yarp::sig::Matrix Module::retrieve_reachable_pose()
 {
     yarp::sig::Matrix reachability_result;

--- a/src/ergocub_cartesian_service/gb-ergocub-cartesian-service/service.thrift
+++ b/src/ergocub_cartesian_service/gb-ergocub-cartesian-service/service.thrift
@@ -29,6 +29,8 @@ service ergoCubCartesianService
 
     bool ask_reachability_evaluation(1: YARPMatrix pose);
 
+    bool is_pose_reachable(1: double x, 2: double y, 3: double z, 4: double q_x, 5: double q_y, 6: double q_z, 7: double q_w);
+
     YARPMatrix retrieve_reachable_pose();
 
     bool stop();

--- a/src/ergocub_cartesian_service/include/gb-ergocub-cartesian-service/ergoCubCartesianService.h
+++ b/src/ergocub_cartesian_service/include/gb-ergocub-cartesian-service/ergoCubCartesianService.h
@@ -38,6 +38,8 @@ public:
 
     virtual bool ask_reachability_evaluation(const yarp::sig::Matrix& pose);
 
+    virtual bool is_pose_reachable(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w);
+
     virtual yarp::sig::Matrix retrieve_reachable_pose();
 
     virtual bool stop();

--- a/src/ergocub_cartesian_service/src/ergoCubCartesianService.cpp
+++ b/src/ergocub_cartesian_service/src/ergoCubCartesianService.cpp
@@ -521,6 +521,75 @@ public:
     static constexpr const char* s_help{""};
 };
 
+// is_pose_reachable helper class declaration
+class ergoCubCartesianService_is_pose_reachable_helper :
+        public yarp::os::Portable
+{
+public:
+    ergoCubCartesianService_is_pose_reachable_helper() = default;
+    ergoCubCartesianService_is_pose_reachable_helper(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w);
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    class Command :
+            public yarp::os::idl::WirePortable
+    {
+    public:
+        Command() = default;
+        Command(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w);
+
+        ~Command() override = default;
+
+        bool write(yarp::os::ConnectionWriter& connection) const override;
+        bool read(yarp::os::ConnectionReader& connection) override;
+
+        bool write(const yarp::os::idl::WireWriter& writer) const override;
+        bool writeTag(const yarp::os::idl::WireWriter& writer) const;
+        bool writeArgs(const yarp::os::idl::WireWriter& writer) const;
+
+        bool read(yarp::os::idl::WireReader& reader) override;
+        bool readTag(yarp::os::idl::WireReader& reader);
+        bool readArgs(yarp::os::idl::WireReader& reader);
+
+        double x{0.0};
+        double y{0.0};
+        double z{0.0};
+        double q_x{0.0};
+        double q_y{0.0};
+        double q_z{0.0};
+        double q_w{0.0};
+    };
+
+    class Reply :
+            public yarp::os::idl::WirePortable
+    {
+    public:
+        Reply() = default;
+        ~Reply() override = default;
+
+        bool write(yarp::os::ConnectionWriter& connection) const override;
+        bool read(yarp::os::ConnectionReader& connection) override;
+
+        bool write(const yarp::os::idl::WireWriter& writer) const override;
+        bool read(yarp::os::idl::WireReader& reader) override;
+
+        bool return_helper{false};
+    };
+
+    using funcptr_t = bool (*)(const double, const double, const double, const double, const double, const double, const double);
+    void call(ergoCubCartesianService* ptr);
+
+    Command cmd;
+    Reply reply;
+
+    static constexpr const char* s_tag{"is_pose_reachable"};
+    static constexpr size_t s_tag_len{3};
+    static constexpr size_t s_cmd_len{10};
+    static constexpr size_t s_reply_len{1};
+    static constexpr const char* s_prototype{"bool ergoCubCartesianService::is_pose_reachable(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w)"};
+    static constexpr const char* s_help{""};
+};
+
 // retrieve_reachable_pose helper class declaration
 class ergoCubCartesianService_retrieve_reachable_pose_helper :
         public yarp::os::Portable
@@ -2016,6 +2085,232 @@ void ergoCubCartesianService_ask_reachability_evaluation_helper::call(ergoCubCar
     reply.return_helper = ptr->ask_reachability_evaluation(cmd.pose);
 }
 
+// is_pose_reachable helper class implementation
+ergoCubCartesianService_is_pose_reachable_helper::ergoCubCartesianService_is_pose_reachable_helper(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w) :
+        cmd{x, y, z, q_x, q_y, q_z, q_w}
+{
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    return cmd.write(connection);
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::read(yarp::os::ConnectionReader& connection)
+{
+    return reply.read(connection);
+}
+
+ergoCubCartesianService_is_pose_reachable_helper::Command::Command(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w) :
+        x{x},
+        y{y},
+        z{z},
+        q_x{q_x},
+        q_y{q_y},
+        q_z{q_z},
+        q_w{q_w}
+{
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Command::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(s_cmd_len)) {
+        return false;
+    }
+    return write(writer);
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Command::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListHeader()) {
+        reader.fail();
+        return false;
+    }
+    return read(reader);
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Command::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writeTag(writer)) {
+        return false;
+    }
+    if (!writeArgs(writer)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Command::writeTag(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeTag(s_tag, 1, s_tag_len)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Command::writeArgs(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.writeFloat64(x)) {
+        return false;
+    }
+    if (!writer.writeFloat64(y)) {
+        return false;
+    }
+    if (!writer.writeFloat64(z)) {
+        return false;
+    }
+    if (!writer.writeFloat64(q_x)) {
+        return false;
+    }
+    if (!writer.writeFloat64(q_y)) {
+        return false;
+    }
+    if (!writer.writeFloat64(q_z)) {
+        return false;
+    }
+    if (!writer.writeFloat64(q_w)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Command::read(yarp::os::idl::WireReader& reader)
+{
+    if (!readTag(reader)) {
+        return false;
+    }
+    if (!readArgs(reader)) {
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Command::readTag(yarp::os::idl::WireReader& reader)
+{
+    std::string tag = reader.readTag(s_tag_len);
+    if (reader.isError()) {
+        return false;
+    }
+    if (tag != s_tag) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Command::readArgs(yarp::os::idl::WireReader& reader)
+{
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(x)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(y)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(z)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(q_x)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(q_y)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(q_z)) {
+        reader.fail();
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readFloat64(q_w)) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Reply::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    return write(writer);
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Reply::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    return read(reader);
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Reply::write(const yarp::os::idl::WireWriter& writer) const
+{
+    if (!writer.isNull()) {
+        if (!writer.writeListHeader(s_reply_len)) {
+            return false;
+        }
+        if (!writer.writeBool(return_helper)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ergoCubCartesianService_is_pose_reachable_helper::Reply::read(yarp::os::idl::WireReader& reader)
+{
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (reader.noMore()) {
+        reader.fail();
+        return false;
+    }
+    if (!reader.readBool(return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
+void ergoCubCartesianService_is_pose_reachable_helper::call(ergoCubCartesianService* ptr)
+{
+    reply.return_helper = ptr->is_pose_reachable(cmd.x, cmd.y, cmd.z, cmd.q_x, cmd.q_y, cmd.q_z, cmd.q_w);
+}
+
 // retrieve_reachable_pose helper class implementation
 bool ergoCubCartesianService_retrieve_reachable_pose_helper::write(yarp::os::ConnectionWriter& connection) const
 {
@@ -2362,6 +2657,16 @@ bool ergoCubCartesianService::ask_reachability_evaluation(const yarp::sig::Matri
     return ok ? helper.reply.return_helper : bool{};
 }
 
+bool ergoCubCartesianService::is_pose_reachable(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w)
+{
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", ergoCubCartesianService_is_pose_reachable_helper::s_prototype);
+    }
+    ergoCubCartesianService_is_pose_reachable_helper helper{x, y, z, q_x, q_y, q_z, q_w};
+    bool ok = yarp().write(helper, helper);
+    return ok ? helper.reply.return_helper : bool{};
+}
+
 yarp::sig::Matrix ergoCubCartesianService::retrieve_reachable_pose()
 {
     if (!yarp().canWrite()) {
@@ -2397,6 +2702,7 @@ std::vector<std::string> ergoCubCartesianService::help(const std::string& functi
         helpString.emplace_back(ergoCubCartesianService_go_home_helper::s_tag);
         helpString.emplace_back(ergoCubCartesianService_is_motion_done_helper::s_tag);
         helpString.emplace_back(ergoCubCartesianService_ask_reachability_evaluation_helper::s_tag);
+        helpString.emplace_back(ergoCubCartesianService_is_pose_reachable_helper::s_tag);
         helpString.emplace_back(ergoCubCartesianService_retrieve_reachable_pose_helper::s_tag);
         helpString.emplace_back(ergoCubCartesianService_stop_helper::s_tag);
         helpString.emplace_back("help");
@@ -2424,6 +2730,9 @@ std::vector<std::string> ergoCubCartesianService::help(const std::string& functi
         }
         if (functionName == ergoCubCartesianService_ask_reachability_evaluation_helper::s_tag) {
             helpString.emplace_back(ergoCubCartesianService_ask_reachability_evaluation_helper::s_prototype);
+        }
+        if (functionName == ergoCubCartesianService_is_pose_reachable_helper::s_tag) {
+            helpString.emplace_back(ergoCubCartesianService_is_pose_reachable_helper::s_prototype);
         }
         if (functionName == ergoCubCartesianService_retrieve_reachable_pose_helper::s_tag) {
             helpString.emplace_back(ergoCubCartesianService_retrieve_reachable_pose_helper::s_prototype);
@@ -2570,6 +2879,21 @@ bool ergoCubCartesianService::read(yarp::os::ConnectionReader& connection)
         }
         if (tag == ergoCubCartesianService_ask_reachability_evaluation_helper::s_tag) {
             ergoCubCartesianService_ask_reachability_evaluation_helper helper;
+            if (!helper.cmd.readArgs(reader)) {
+                return false;
+            }
+
+            helper.call(this);
+
+            yarp::os::idl::WireWriter writer(reader);
+            if (!helper.reply.write(writer)) {
+                return false;
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == ergoCubCartesianService_is_pose_reachable_helper::s_tag) {
+            ergoCubCartesianService_is_pose_reachable_helper helper;
             if (!helper.cmd.readArgs(reader)) {
                 return false;
             }

--- a/src/r1_cartesian_control/app/conf/config_left.ini
+++ b/src/r1_cartesian_control/app/conf/config_left.ini
@@ -1,0 +1,36 @@
+rate 100.0
+traj_duration 5.0
+rpc_local_port_name /r1-cartesian-control/left_arm/rpc:i
+position_error_th 0.0005
+max_iteration 10000
+module_logging true
+module_verbose true
+qp_verbose false
+
+[ARM]
+
+name left_arm
+
+joint_axes_list (l_shoulder_pitch l_shoulder_roll l_shoulder_yaw l_elbow l_wrist_yaw l_wrist_roll l_wrist_pitch) #order matters
+joint_ports_list (/cer/left_arm)
+joint_local_port /r1-cartesian-control/left_arm
+
+[IK_PARAM]
+
+limits_param 0.90 # 0 < limits_param < 1
+joint_vel_weight (5.0 0.0) #(cost weight, cost offset)
+position_param (20.0 0.5) #(cost weight, proportional gain)
+orientation_param (10.0 0.5) #(cost weight, proportional gain)
+joint_pos_param (2.5 10.0 5.0)  #(cost weight, proportional gain, derivative gain)
+max_joint_position_variation 25.0 #[deg]
+max_joint_position_track_error 1.5 #[deg]
+#joint_ref (0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
+
+[FK_PARAM]
+
+root_frame_name base_link
+ee_frame_name l_hand_palm
+
+[FSM_PARAM]
+
+stop_speed 0.001 #[rad] =  0.286478898 deg

--- a/src/r1_cartesian_control/app/conf/config_left_sim_r1_hand_pointing.ini
+++ b/src/r1_cartesian_control/app/conf/config_left_sim_r1_hand_pointing.ini
@@ -1,0 +1,36 @@
+rate 100.0
+traj_duration 7.0
+rpc_local_port_name /r1-cartesian-control/left_arm/rpc:i
+position_error_th 0.005
+max_iteration 100000
+module_logging true
+module_verbose true
+qp_verbose false
+
+[ARM]
+
+name left_arm
+
+joint_axes_list (l_shoulder_pitch l_shoulder_roll l_shoulder_yaw l_elbow l_wrist_yaw l_wrist_roll l_wrist_pitch) #order matters
+joint_ports_list (/r1mk3Sim/left_arm)
+joint_local_port /r1-cartesian-control/left_arm
+
+[IK_PARAM]
+
+limits_param 0.90 # 0 < limits_param < 1
+joint_vel_weight (20.0 0.0) #(cost weight, cost offset)
+position_param (20.0 0.5) #(cost weight, proportional gain)
+orientation_param (10.0 0.5) #(cost weight, proportional gain)
+joint_pos_param (2.5 10.0 5.0)  #(cost weight, proportional gain, derivative gain)
+max_joint_position_variation 5.0 #[deg]
+max_joint_position_track_error 1.5 #[deg]
+joint_ref (0.0 0.1 0.0 0.1 0.0 0.0 0.0)
+
+[FK_PARAM]
+
+root_frame_name base_link
+ee_frame_name l_hand_palm
+
+[FSM_PARAM]
+
+stop_speed 0.01 #[rad] =  0.286478898 deg

--- a/src/r1_cartesian_control/app/conf/config_right.ini
+++ b/src/r1_cartesian_control/app/conf/config_right.ini
@@ -1,0 +1,36 @@
+rate 100.0
+traj_duration 5.0
+rpc_local_port_name /r1-cartesian-control/right_arm/rpc:i
+position_error_th 0.0005
+max_iteration 10000
+module_logging true
+module_verbose true
+qp_verbose false
+
+[ARM]
+
+name right_arm
+
+joint_axes_list (r_shoulder_pitch r_shoulder_roll r_shoulder_yaw r_elbow r_wrist_yaw r_wrist_roll r_wrist_pitch) #order matters
+joint_ports_list (/cer/right_arm)
+joint_local_port /r1-cartesian-control/right_arm
+
+[IK_PARAM]
+
+limits_param 0.90 # 0 < limits_param < 1
+joint_vel_weight (5.0 0.0) #(cost weight, cost offset)
+position_param (20.0 0.5) #(cost weight, proportional gain)
+orientation_param (10.0 0.5) #(cost weight, proportional gain)
+joint_pos_param (2.5 10.0 5.0)  #(cost weight, proportional gain, derivative gain)
+max_joint_position_variation 25.0 #[deg]
+max_joint_position_track_error 1.5 #[deg]
+#joint_ref (0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
+
+[FK_PARAM]
+
+root_frame_name base_link
+ee_frame_name r_hand_palm
+
+[FSM_PARAM]
+
+stop_speed 0.001 #[rad] =  0.286478898 deg

--- a/src/r1_cartesian_control/app/conf/config_right_sim_r1_hand_pointing.ini
+++ b/src/r1_cartesian_control/app/conf/config_right_sim_r1_hand_pointing.ini
@@ -1,0 +1,36 @@
+rate 100.0
+traj_duration 7.0
+rpc_local_port_name /r1-cartesian-control/right_arm/rpc:i
+position_error_th 0.005
+max_iteration 100000
+module_logging true
+module_verbose true
+qp_verbose false
+
+[ARM]
+
+name right_arm
+
+joint_axes_list (r_shoulder_pitch r_shoulder_roll r_shoulder_yaw r_elbow r_wrist_yaw r_wrist_roll r_wrist_pitch) #order matters
+joint_ports_list (/r1mk3Sim/right_arm)
+joint_local_port /r1-cartesian-control/right_arm
+
+[IK_PARAM]
+
+limits_param 0.90 # 0 < limits_param < 1
+joint_vel_weight (20.0 0.0) #(cost weight, cost offset)
+position_param (20.0 0.5) #(cost weight, proportional gain)
+orientation_param (10.0 0.5) #(cost weight, proportional gain)
+joint_pos_param (2.5 10.0 5.0)  #(cost weight, proportional gain, derivative gain)
+max_joint_position_variation 5.0 #[deg]
+max_joint_position_track_error 1.5 #[deg]
+joint_ref (0.0 0.1 0.0 0.1 0.0 0.0 0.0)
+
+[FK_PARAM]
+
+root_frame_name base_link
+ee_frame_name r_hand_palm
+
+[FSM_PARAM]
+
+stop_speed 0.01 #[rad] =  0.286478898 deg

--- a/src/r1_cartesian_control/include/module.h
+++ b/src/r1_cartesian_control/include/module.h
@@ -46,6 +46,8 @@ public:
 
     bool ask_reachability_evaluation(const yarp::sig::Matrix &pose);
 
+    bool is_pose_reachable(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w);
+
     yarp::sig::Matrix retrieve_reachable_pose();
 
     bool stop();

--- a/src/r1_cartesian_control/src/module_service.cpp
+++ b/src/r1_cartesian_control/src/module_service.cpp
@@ -102,6 +102,21 @@ yarp::sig::Matrix Module::retrieve_reachable_pose()
     return reachability_result;
 }
 
+bool Module::is_pose_reachable(const double x, const double y, const double z, const double q_x, const double q_y, const double q_z, const double q_w)
+{
+    if (getState() != State::Stop)
+        return false;
+
+    Eigen::Affine3d target_pose;
+    target_pose = Eigen::Translation3d(x, y, z);
+    target_pose.rotate(Eigen::Quaterniond(q_w, q_x, q_y, q_z));
+
+    serviceTrajInit(true, target_pose, getDuration());
+
+    return true;
+}
+
+
 bool Module::stop()
 {
     setState(State::Stop);


### PR DESCRIPTION
## Summary

We are adding a utility to check via rpc whether a pose is reachable or not by the system. Piggybacking also some config that are used in r1 hand pointing in simulation and that may also come in handy as a general configuration.

## Added
- `bool is_pose_reachable(x,y,z,qx,qy,qz,qw)` method to quickly check whether a configuration is reachable by the system. This is useful for debugging purposes.
- Some configuration files both for the real r1 and for the simulation to perform hand pointing. In particular, this set of parameters may generate trajectories that should fare better when the elbow is close to a singularity