### PR TITLE
Fixed default context for r1-cart-control

### DIFF
--- a/src/r1_cartesian_control/app/conf/config_left_sim_r1.ini
+++ b/src/r1_cartesian_control/app/conf/config_left_sim_r1.ini
@@ -1,10 +1,10 @@
 rate 100.0
 traj_duration 5.0
 rpc_local_port_name /r1-cartesian-control/left_arm/rpc:i
-position_error_th 0.0005
+position_error_th 0.005
 max_iteration 10000
-module_logging false
-module_verbose false
+module_logging true
+module_verbose true
 qp_verbose false
 
 [ARM]
@@ -24,7 +24,7 @@ orientation_param (10.0 0.5) #(cost weight, proportional gain)
 joint_pos_param (2.5 10.0 5.0)  #(cost weight, proportional gain, derivative gain)
 max_joint_position_variation 25.0 #[deg]
 max_joint_position_track_error 1.5 #[deg]
-#joint_ref (0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
+# joint_ref (0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
 
 [FK_PARAM]
 
@@ -33,4 +33,4 @@ ee_frame_name l_hand_palm
 
 [FSM_PARAM]
 
-stop_speed 0.001 #[rad] =  0.286478898 deg
+stop_speed 0.005 #[rad] =  0.286478898 deg

--- a/src/r1_cartesian_control/app/conf/config_right_sim_r1.ini
+++ b/src/r1_cartesian_control/app/conf/config_right_sim_r1.ini
@@ -1,10 +1,10 @@
 rate 100.0
 traj_duration 5.0
 rpc_local_port_name /r1-cartesian-control/right_arm/rpc:i
-position_error_th 0.0005
+position_error_th 0.005
 max_iteration 10000
-module_logging false
-module_verbose false
+module_logging true
+module_verbose true
 qp_verbose false
 
 [ARM]
@@ -24,7 +24,7 @@ orientation_param (10.0 0.5) #(cost weight, proportional gain)
 joint_pos_param (2.5 10.0 5.0)  #(cost weight, proportional gain, derivative gain)
 max_joint_position_variation 25.0 #[deg]
 max_joint_position_track_error 1.5 #[deg]
-#joint_ref (0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
+# joint_ref (0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
 
 [FK_PARAM]
 
@@ -33,4 +33,4 @@ ee_frame_name r_hand_palm
 
 [FSM_PARAM]
 
-stop_speed 0.001 #[rad] =  0.286478898 deg
+stop_speed 0.005 #[rad] =  0.286478898 deg

--- a/src/r1_cartesian_control/src/main.cpp
+++ b/src/r1_cartesian_control/src/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv)
     /* Load configuration file. */
     yarp::os::ResourceFinder rf;
     rf.setVerbose(false);
-    rf.setDefaultContext("gb-ergocub-cartesian-controller");
+    rf.setDefaultContext("r1-cartesian-control");
     rf.setDefaultConfigFile("config_right.ini");
     rf.configure(argc, argv);
 


### PR DESCRIPTION
## Modified
- Now the default context of `r1-cartesian-control` is correctly `r1-cartesian-control`
- Minor tweaks to `config_left_sim_r1.ini` and `config_right_sim_r1.ini`