### PR TITLE
Clean the utils directory

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(${LIBRARY_TARGET_NAME} STATIC ${${LIBRARY_TARGET_NAME}_SRC} ${${LIBR
 # Library properties
 set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES 
     VERSION       ${${PROJECT_NAME}_VERSION}
-    PUBLIC_HEADER "${headers}"
+    PUBLIC_HEADER "${${LIBRARY_TARGET_NAME}_HDR}"
     EXPORT_NAME ${LIBRARY_TARGET_NAME}  # Set consistent export name
 )
 

--- a/src/utils/include/utils/utils.h
+++ b/src/utils/include/utils/utils.h
@@ -15,7 +15,6 @@ namespace utils
     Eigen::VectorXd loadVectorInt(const yarp::os::Bottle& rf, const std::string& key);
     Eigen::VectorXd loadVectorDouble(const yarp::os::Bottle& rf, const std::string& key);
     std::vector<std::string> loadVectorString(const yarp::os::Bottle& rf, const std::string& key);
-    double evaluateReachabilityScore(const Eigen::Transform<double, 3, Eigen::Affine>& target_pose, const Eigen::Transform<double, 3, Eigen::Affine>& reachable_pose, const double position_threshold, const double orientation_threshold);
 }
 
 
@@ -62,15 +61,5 @@ Eigen::VectorXd utils::loadVectorDouble(const yarp::os::Bottle& bottle, const st
  * @return A std::vector<std::string> containing the extracted vector.
  */
 std::vector<std::string> utils::loadVectorString(const yarp::os::Bottle& bottle, const std::string& key);
-
-/**
- * Given a set of target and reachable end-effector poses, it returns a score consisting in
- * the rotational error between the two poses in the range [0, 1], if the positional error and the orientation error is below a given threshold.
- * Otherwise, the score gets assigned a maximu value of std::numeric_limits<double>::infinity().
- * @param target_pose A Eigen::Transform<double, 3, Eigen::Affine> containing the target pose of the end-effector.
- * @param reachable_pose A Eigen::Transform<double, 3, Eigen::Affine> containing the reachable pose of the end-effector.
- * @return The score as a double.
- */
-double utils::evaluateReachabilityScore(const Eigen::Transform<double, 3, Eigen::Affine>& target_pose, const Eigen::Transform<double, 3, Eigen::Affine>& reachable_pose, const double position_threshold, const double orientation_threshold);
 
 #endif

--- a/src/utils/src/utils.cpp
+++ b/src/utils/src/utils.cpp
@@ -57,26 +57,3 @@ std::vector<std::string> utils::loadVectorString(const yarp::os::Bottle& bottle,
 
     return vector;
 }
-
-
-double utils::evaluateReachabilityScore(const Eigen::Transform<double, 3, Eigen::Affine>& target_pose, const Eigen::Transform<double, 3, Eigen::Affine>& reachable_pose, const double position_threshold, const double orientation_threshold)
-{
-    /*  Evaluate the rotational error as the norm of the "vee" of the logarithm of the error matrix between target_pose.rotation and reacheable_pose.rotation.
-        Such a metric provides values in [0, pi]
-        References: https://arxiv.org/pdf/1812.01537.pdf, Fig. 6 (for the "vee" operator)
-                    https://www.cs.cmu.edu/~cga/dynopt/readings/Rmetric.pdf, Eq. 23 (for the rotational error definition)
-        */
-    Eigen::Matrix3d error = target_pose.rotation() * reachable_pose.rotation().transpose();
-    Eigen::Vector3d vee_of_log = Eigen::AngleAxisd(error).axis() * Eigen::AngleAxisd(error).angle();
-    double rotational_error = vee_of_log.norm();
-
-    if ((target_pose.translation() - reachable_pose.translation()).norm() < position_threshold && rotational_error < orientation_threshold)
-    {
-        /* Divide by pi to obtain the score in [0, 1]*/
-        return rotational_error / M_PI;
-    }
-    else
-    {
-        return std::numeric_limits<double>::infinity();
-    }
-}


### PR DESCRIPTION
A small PR to fix utils installation

## Fixes 
- Now utils.hpp gets correctly installed
- Removed function that is only used in grasp exec in grasping-baselines.