### PR TITLE
fix: now environment includes g++ compiler

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,6 @@ dependencies:
   - cmake>=3.16
   - ninja
   - pybind11>=2.10
+  - cxx-compiler==1.11.0
   - pip:
       - scikit-build-core>=0.9


### PR DESCRIPTION
### Fixed 

- Fixed a bug where the build of the repo, with dependencies installed via conda, was dependent on the compiler version on the host.