### PR TITLE
CMake error fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,22 @@ ENV LANG=en_US.UTF-8
 
 # Install essentials
 RUN apt update && \
-    apt install --no-install-recommends -y -qq apt-utils build-essential ca-certificates cmake cmake-curses-gui curl git glmark2 gnupg2 htop iputils-ping jq lsb-release mesa-utils nano psmisc python3-virtualenv sudo unzip vim wget zip && \
+    apt install --no-install-recommends -y -qq apt-utils build-essential ca-certificates cmake-curses-gui curl git glmark2 gnupg2 htop iputils-ping jq lsb-release mesa-utils nano psmisc python3-virtualenv sudo unzip vim wget zip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add Kitware repo (maintains latest cmake)
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
+    | tee /etc/apt/sources.list.d/kitware.list && \
+    apt-get update && \
+    apt-get install -y cmake && \
     rm -rf /var/lib/apt/lists/*
 
 # Install additional dependencies for the robotology superbuild
 RUN apt update && \
     git clone https://github.com/robotology/robotology-superbuild && \
     cd robotology-superbuild && \
-    git checkout v2025.02.0 && \
+    git checkout v2023.05.2 && \
     bash scripts/install_apt_dependencies.sh && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf ../robotology-superbuild
@@ -48,7 +56,7 @@ WORKDIR /home/user
 RUN git clone https://github.com/robotology/robotology-superbuild && \
     cd robotology-superbuild && \
     git fetch -a && \
-    git checkout v2025.02.0 && \
+    git checkout v2025.05.0 && \
     git config --local user.name "user" && \
     git config --local user.email "user@email.com" && \
     mkdir build && cd build && \
@@ -57,6 +65,9 @@ RUN git clone https://github.com/robotology/robotology-superbuild && \
 
 # Setup robotology superbuild
 RUN echo "source /home/user/robotology-superbuild/build/install/share/robotology-superbuild/setup.sh" >> /home/user/.bashrc
+
+# Install pybind11 (C++ dev package for CMake)
+RUN sudo apt-get update && sudo apt-get install -y pybind11-dev && sudo rm -rf /var/lib/apt/lists/*
 
 # Clone and build ergocub-cartesian-control
 RUN source /home/user/robotology-superbuild/build/install/share/robotology-superbuild/setup.sh && \


### PR DESCRIPTION
This update addresses build errors caused by an outdated version of CMake. Changes include:
- Added the official Kitware APT repository to ensure installation of the latest stable CMake version.
- Updated the robotology-superbuild checkout versions to compatible tags (v2023.05.2 for dependencies and v2025.05.0 for main build).
- Added installation of pybind11-dev to support C++/Python bindings required by some modules.