### PR TITLE
Bimanual - WalkingController Integration

### DIFF
--- a/src/ergocub_cartesian_bimanual/CMakeLists.txt
+++ b/src/ergocub_cartesian_bimanual/CMakeLists.txt
@@ -37,6 +37,9 @@ if(BUILD_BIMANUAL_EXECUTABLE)
   find_package(BipedalLocomotionFramework 0.18.0
     COMPONENTS  VectorsCollection
                 ParametersHandlerYarpImplementation REQUIRED)
+
+  # WalkingControllers
+  find_package(WalkingControllers REQUIRED)
 endif()
 
 # Python bindings 
@@ -109,6 +112,7 @@ if(BUILD_BIMANUAL_EXECUTABLE)
                                            utils
                                            BipedalLocomotion::VectorsCollection
                                            BipedalLocomotion::ParametersHandlerYarpImplementation
+                                           WalkingControllers::HumanState
   )
 
   # YARP logging is always enabled via includes; no special defines needed

--- a/src/ergocub_cartesian_bimanual/app/conf/real/common.ini
+++ b/src/ergocub_cartesian_bimanual/app/conf/real/common.ini
@@ -4,4 +4,5 @@ module_verbose false
 qp_verbose false
 rpc_local_port_name /mc-ergocub-cartesian-bimanual/rpc:i
 ctrl_local_port_name /mc-ergocub-cartesian-bimanual/cmd:i
+walking_controller_local_port /mc-ergocub-cartesian-bimanual/walkingModuleInterface:o
 no_control false

--- a/src/ergocub_cartesian_bimanual/app/conf/sim/common.ini
+++ b/src/ergocub_cartesian_bimanual/app/conf/sim/common.ini
@@ -4,5 +4,6 @@ module_verbose false
 qp_verbose false
 rpc_local_port_name /mc-ergocub-cartesian-bimanual/rpc:i
 ctrl_local_port_name /mc-ergocub-cartesian-bimanual/cmd:i
+#walking_controller_local_port /mc-ergocub-cartesian-bimanual/walkingModuleInterface:o
 # if this is set to true, the module will not command the robot, but will only output the joint positions on a port
 no_control false

--- a/src/ergocub_cartesian_bimanual/include/module.h
+++ b/src/ergocub_cartesian_bimanual/include/module.h
@@ -10,10 +10,12 @@
 #include <yarp/os/BufferedPort.h>
 
 #include <BipedalLocomotion/YarpUtilities/VectorsCollectionServer.h>
+#include <WalkingControllers/YarpUtilities/HumanState.h>
 
 #include <memory>
-#include <string.h>
 #include <mutex>
+#include <string.h>
+#include <vector>
 
 #include <ForwardKinematicsiDynTree.h>
 #include <cub-joint-control/cubJointControl.h>
@@ -71,6 +73,8 @@ private:
     yarp::os::BufferedPort<yarp::os::Bottle> rpc_cmd_port_;
     yarp::os::BufferedPort<yarp::sig::Vector> bp_cmd_port_;
     yarp::os::BufferedPort<yarp::sig::Vector> joints_pos_port_;
+    yarp::os::BufferedPort<WalkingControllers::YarpUtilities::HumanState> walkingModuleInterface_;
+    std::vector<std::string> walking_joint_names_;
     bool no_control_{false};
 
     /* Forward kinematics */
@@ -135,6 +139,7 @@ private:
     /* HELPER function*/
     void appendEigen(Eigen::VectorXd &vec, const Eigen::VectorXd &vec_app);
     Eigen::VectorXd concatenateEigen(const Eigen::VectorXd &vec1, const Eigen::VectorXd &vec2);
+    bool publishToWalkingController(const Eigen::VectorXd &joint_refs);
 
     /* Thrift service configuration */
     bool configureService(const yarp::os::ResourceFinder &rf, const std::string rpc_port_name);

--- a/src/ergocub_cartesian_bimanual/src/module.cpp
+++ b/src/ergocub_cartesian_bimanual/src/module.cpp
@@ -58,6 +58,8 @@ bool Module::configure(yarp::os::ResourceFinder &rf)
     module_verbose_ = COMMON_bot.find("module_verbose").asBool();
     const bool qp_verbose = COMMON_bot.find("qp_verbose").asBool();
     const std::string rpc_local_port_name = COMMON_bot.find("rpc_local_port_name").asString();
+    const std::string walking_controller_local_port =
+        COMMON_bot.check("walking_controller_local_port", yarp::os::Value("")).asString();
     bp_cmd_port_.open(COMMON_bot.find("ctrl_local_port_name").asString());
     no_control_ = COMMON_bot.check("no_control") ? COMMON_bot.find("no_control").asBool() : false;
     if (no_control_)
@@ -119,6 +121,33 @@ bool Module::configure(yarp::os::ResourceFinder &rf)
             ||  !(utils::checkParameters({{"joint_pos_weight", "joint_pos_p_gain", "joint_pos_d_gain"}}, "", TORSO_bot, "", utils::ParameterType::Float64, true)))
         {
             yError() << "[" + module_name_ + "::configure] Error: mandatory parameter(s) for TORSO group missing or invalid.";
+            return false;
+        }
+    }
+
+    if (!walking_controller_local_port.empty())
+    {
+        if (right_enabled_)
+        {
+            auto right_joint_names = utils::loadVectorString(RIGHT_ARM_bot, "joint_axes_list");
+            walking_joint_names_.insert(walking_joint_names_.end(), right_joint_names.begin(), right_joint_names.end());
+        }
+
+        if (left_enabled_)
+        {
+            auto left_joint_names = utils::loadVectorString(LEFT_ARM_bot, "joint_axes_list");
+            walking_joint_names_.insert(walking_joint_names_.end(), left_joint_names.begin(), left_joint_names.end());
+        }
+
+        if (torso_enabled_)
+        {
+            auto torso_joint_names = utils::loadVectorString(TORSO_bot, "joint_axes_list");
+            walking_joint_names_.insert(walking_joint_names_.end(), torso_joint_names.begin(), torso_joint_names.end());
+        }
+
+        if (!walkingModuleInterface_.open(walking_controller_local_port))
+        {
+            yError() << "[" + module_name_ + "::configure] Error: cannot open the walking controller port.";
             return false;
         }
     }
@@ -465,6 +494,7 @@ bool Module::close()
     rpc_cmd_port_.close();
     bp_cmd_port_.close();
     joints_pos_port_.close();
+    walkingModuleInterface_.close();
 
     return true;
 }
@@ -479,6 +509,7 @@ bool Module::interruptModule()
     rpc_cmd_port_.interrupt();
     bp_cmd_port_.interrupt();
     joints_pos_port_.interrupt();
+    walkingModuleInterface_.interrupt();
 
     return true;
 }
@@ -956,6 +987,11 @@ bool Module::moveChains()
 {
     Eigen::VectorXd joint_refs = compound_chain_.joints.pos;
 
+    if (!walking_joint_names_.empty())
+    {
+        return publishToWalkingController(joint_refs);
+    }
+
     int nR = right_enabled_ ? right_arm_.cjc.getNumberJoints() : 0;
     int nL = left_enabled_  ? left_arm_.cjc.getNumberJoints()  : 0;
     int nT = torso_enabled_ ? torso_.cjc.getNumberJoints()     : 0;
@@ -989,6 +1025,24 @@ bool Module::moveChains()
         }
         offset += nT;
     }
+
+    return true;
+}
+
+
+bool Module::publishToWalkingController(const Eigen::VectorXd &joint_refs)
+{
+    if (walking_joint_names_.size() != static_cast<size_t>(joint_refs.size()))
+    {
+        yError() << "[" + module_name_ + "::publishToWalkingController] Error: joint size mismatch.";
+        return false;
+    }
+
+    auto &walking_module_data = walkingModuleInterface_.prepare();
+    walking_module_data.jointNames = walking_joint_names_;
+    walking_module_data.positions.assign(joint_refs.data(), joint_refs.data() + joint_refs.size());
+
+    walkingModuleInterface_.write();
 
     return true;
 }


### PR DESCRIPTION
when a local port for the walking controller is specified the bimanual does not directly control the robot but it sends the reference to the WC for retargeting.